### PR TITLE
"AbstractFinder"の"match"メソッドにreturnを追加

### DIFF
--- a/politylink/helpers/abstract_finder.py
+++ b/politylink/helpers/abstract_finder.py
@@ -21,6 +21,7 @@ class AbstractFinder:
                 for field_text in extract_texts(getattr(obj, field)):
                     if field_text and (text in field_text or field_text in text):
                         return True
+        return False
 
 
 def extract_texts(value) -> List[str]:


### PR DESCRIPTION
`AbstractFinder`の`match`メソッドにおいて条件を満たさなかったときに`None`が返るようになっていたので`return False`するように修正。（動作結果に変化なし）