### PR TITLE
POL-257: manual install of pke

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 ```
 pip install politylink
 ```
-`politylink.nlp.keyphrase`を使用する場合は、NLTKのストップワードをダウンロードしてください。
+`politylink.nlp.keyphrase`を使用する場合は、追加で以下を行ってください。
+- pkeのインストール
+- NLTKのストップワードのダウンロード
 ```
+pip install git+https://github.com/boudinfl/pke.git
+
 python -m nltk.downloader stopwords
 ```
 ## 使い方

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ sgqlc = "^11.0"
 kanjize = "^0.1.0"
 elasticsearch = "^7.9.1"
 nltk = "^3.5"
-pke = { git = "https://github.com/boudinfl/pke.git" }
 spacy = "^2.3.5"
 ginza = "^4.0.5"
 


### PR DESCRIPTION
- pyproject.tomlのdependenciesから、pkeを削除（PyPIは non-package dependenciesをサポートしていない　参考：https://github.com/python-poetry/poetry/issues/2828 ）
- READMEにpkeの手動インストールの文を追加